### PR TITLE
fix: Remove unused regexp import and finalize features

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"


### PR DESCRIPTION
- Removes the 'regexp' package import which was no longer used after refactoring the `!add` command, fixing a compile error.
- This commit finalizes the merging of features from two previous versions of the bot, resulting in a single, robust song request system that includes download timeouts, song validation (duration, live streams), and duplicate checking.